### PR TITLE
Use optional chaining for featuredImage in WpPost

### DIFF
--- a/src/pages/{WpPost.slug}.tsx
+++ b/src/pages/{WpPost.slug}.tsx
@@ -38,7 +38,7 @@ export default function Component({ data }: PostPageProps) {
       slug={post.slug}
       date={post.date}
       categories={post.categories?.nodes}
-      featuredImage={post.featuredImage.node}
+      featuredImage={post.featuredImage?.node}
     />
   )
 }


### PR DESCRIPTION
When a `WpPost` lacks a `featuredImage` accessing the node breaks a build